### PR TITLE
FIX: Handle CXXFLAGS environment variable

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -137,6 +137,15 @@ class BotanConan(ConanFile):
         if self.settings.os != "Windows" and self.options.fPIC:
             botan_extra_cxx_flags.append('-fPIC')
 
+        # This is to work around botan's configure script that *replaces* its
+        # standard (platform dependent) flags in presence of an environment
+        # variable ${CXXFLAGS}. Most notably, this would build botan with
+        # disabled compiler optimizations.
+        environment_cxxflags = tools.get_env("CXXFLAGS")
+        if environment_cxxflags:
+            del os.environ["CXXFLAGS"]
+            botan_extra_cxx_flags.append(environment_cxxflags)
+
         # we're piggy-backing this onto the ABI flags as a workaround:
         # botan's configure script *replaces* it's own standard flags with
         # whatever it gets from --cxxflags. Starting with Botan 2.10 there will

--- a/conanfile.py
+++ b/conanfile.py
@@ -123,6 +123,7 @@ class BotanConan(ConanFile):
             botan_compiler = 'msvc'
 
         botan_abi_flags = []
+        botan_extra_cxx_flags = []
 
         if self._is_linux_clang_libcxx:
             botan_abi_flags.extend(["-stdlib=libc++", "-lc++abi"])
@@ -134,7 +135,10 @@ class BotanConan(ConanFile):
                 botan_abi_flags.append('-m64')
 
         if self.settings.os != "Windows" and self.options.fPIC:
-            botan_abi_flags.append('-fPIC')
+            botan_extra_cxx_flags.append('-fPIC')
+
+        if botan_extra_cxx_flags:
+            botan_abi_flags.extend(botan_extra_cxx_flags)
 
         botan_abi = ' '.join(botan_abi_flags) if botan_abi_flags else ' '
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -137,6 +137,13 @@ class BotanConan(ConanFile):
         if self.settings.os != "Windows" and self.options.fPIC:
             botan_extra_cxx_flags.append('-fPIC')
 
+        # we're piggy-backing this onto the ABI flags as a workaround:
+        # botan's configure script *replaces* it's own standard flags with
+        # whatever it gets from --cxxflags. Starting with Botan 2.10 there will
+        # be an --extra-cxxflags parameter that solves this.
+        # See here for more details:
+        #   https://github.com/bincrafters/community/issues/631
+        #   https://github.com/randombit/botan/issues/1826
         if botan_extra_cxx_flags:
             botan_abi_flags.extend(botan_extra_cxx_flags)
 


### PR DESCRIPTION
Botan's configure script *replaces* its platform dependent standard flags with whatever it receives through either its `--cxxflags` parameter or the `${CXXFLAGS}` environment variable. That's unfortunate because the `-O3` is part of said "standard flags". Without those workaround botan might be built without compiler optimizations for many users.

This is related to the following issues:
 * https://github.com/randombit/botan/issues/1826
 * https://github.com/bincrafters/community/issues/631