### PR TITLE
FIX: Handle CXXFLAGS environment variable on stable/2.9.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -139,6 +139,15 @@ class BotanConan(ConanFile):
         if self.settings.os != "Windows" and self.options.fPIC:
             botan_extra_cxx_flags.append('-fPIC')
 
+        # This is to work around botan's configure script that *replaces* its
+        # standard (platform dependent) flags in presence of an environment
+        # variable ${CXXFLAGS}. Most notably, this would build botan with
+        # disabled compiler optimizations.
+        environment_cxxflags = tools.get_env("CXXFLAGS")
+        if environment_cxxflags:
+            del os.environ["CXXFLAGS"]
+            botan_extra_cxx_flags.append(environment_cxxflags)
+
         # we're piggy-backing this onto the ABI flags as a workaround:
         # botan's configure script *replaces* it's own standard flags with
         # whatever it gets from --cxxflags. Starting with Botan 2.10 there will

--- a/conanfile.py
+++ b/conanfile.py
@@ -139,6 +139,13 @@ class BotanConan(ConanFile):
         if self.settings.os != "Windows" and self.options.fPIC:
             botan_extra_cxx_flags.append('-fPIC')
 
+        # we're piggy-backing this onto the ABI flags as a workaround:
+        # botan's configure script *replaces* it's own standard flags with
+        # whatever it gets from --cxxflags. Starting with Botan 2.10 there will
+        # be an --extra-cxxflags parameter that solves this.
+        # See here for more details:
+        #   https://github.com/bincrafters/community/issues/631
+        #   https://github.com/randombit/botan/issues/1826
         if botan_extra_cxx_flags:
             botan_abi_flags.extend(botan_extra_cxx_flags)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -125,6 +125,7 @@ class BotanConan(ConanFile):
             botan_compiler = 'msvc'
 
         botan_abi_flags = []
+        botan_extra_cxx_flags = []
 
         if self._is_linux_clang_libcxx:
             botan_abi_flags.extend(["-stdlib=libc++", "-lc++abi"])
@@ -135,12 +136,15 @@ class BotanConan(ConanFile):
             elif self.settings.arch == "x86_64":
                 botan_abi_flags.append('-m64')
 
+        if self.settings.os != "Windows" and self.options.fPIC:
+            botan_extra_cxx_flags.append('-fPIC')
+
+        if botan_extra_cxx_flags:
+            botan_abi_flags.extend(botan_extra_cxx_flags)
+
         botan_abi = ' '.join(botan_abi_flags) if botan_abi_flags else ' '
 
         build_flags = []
-
-        if self.settings.os != "Windows" and self.options.fPIC:
-            build_flags.append('--cxxflags=-fPIC')
 
         if self.options.amalgamation:
             build_flags.append('--amalgamation')


### PR DESCRIPTION
This is the same patch like [this one](https://github.com/bincrafters/conan-botan/pull/6), just applied to `stable/2.9.0`.