### PR TITLE
Recipe for Botan 2.10.0

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     brew update || brew update
@@ -13,8 +12,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         eval "$(pyenv init -)"
     fi
 
-    pyenv install 2.7.10
-    pyenv virtualenv 2.7.10 conan
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
     pyenv rehash
     pyenv activate conan
 fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     if which pyenv > /dev/null; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
       - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3
-      - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - <<: *osx

--- a/2006b469c1d1038737c1afe908300fab87d50062.diff
+++ b/2006b469c1d1038737c1afe908300fab87d50062.diff
@@ -1,0 +1,12 @@
+diff --git a/src/lib/x509/certstor_system_macos/certstor_macos.cpp b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+index 3a3652ae1..5672385ae 100644
+--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
++++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+@@ -11,6 +11,7 @@
+ #include <algorithm>
+ #include <array>
+ 
++#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
+ #include <CoreFoundation/CoreFoundation.h>
+ #include <CoreServices/CoreServices.h>
+ 

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,7 +92,7 @@ class BotanConan(ConanFile):
             if self.settings.os == 'Linux':
                 self.cpp_info.libs.append('rt')
             if self.settings.os == 'Macos':
-                self.cpp_info.exelinkflags = ['-framework Security']
+                self.cpp_info.exelinkflags = ['-framework Security', '-framework CoreFoundation']
             if not self.options.shared:
                 self.cpp_info.libs.append('pthread')
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -149,17 +149,8 @@ class BotanConan(ConanFile):
             del os.environ["CXXFLAGS"]
             botan_extra_cxx_flags.append(environment_cxxflags)
 
-        # we're piggy-backing this onto the ABI flags as a workaround:
-        # botan's configure script *replaces* it's own standard flags with
-        # whatever it gets from --cxxflags. Starting with Botan 2.10 there will
-        # be an --extra-cxxflags parameter that solves this.
-        # See here for more details:
-        #   https://github.com/bincrafters/community/issues/631
-        #   https://github.com/randombit/botan/issues/1826
-        if botan_extra_cxx_flags:
-            botan_abi_flags.extend(botan_extra_cxx_flags)
-
         botan_abi = ' '.join(botan_abi_flags) if botan_abi_flags else ' '
+        botan_cxx_extras = ' '.join(botan_extra_cxx_flags) if botan_extra_cxx_flags else ' '
 
         build_flags = []
 
@@ -205,6 +196,7 @@ class BotanConan(ConanFile):
         configure_cmd = ('{python_call} ./configure.py'
                          ' --distribution-info="Conan"'
                          ' --cc-abi-flags="{abi}"'
+                         ' --extra-cxxflags="{cxxflags}"'
                          ' --cc={compiler}'
                          ' --cpu={cpu}'
                          ' --prefix={prefix}'
@@ -212,6 +204,7 @@ class BotanConan(ConanFile):
                          ' {build_flags}').format(
                              python_call=call_python,
                              abi=botan_abi,
+                             cxxflags=botan_cxx_extras,
                              compiler=botan_compiler,
                              cpu=self.settings.arch,
                              prefix=prefix,

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ class BotanConan(ConanFile):
     homepage = "https://github.com/randombit/botan"
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "BSD 2-clause"
-    exports = ["LICENSE.md"]
+    exports = ["LICENSE.md","2006b469c1d1038737c1afe908300fab87d50062.diff"]
     description = "Botan is a cryptography library written in C++11."
     settings = 'os', 'arch', 'compiler', 'build_type'
     options = {
@@ -71,6 +71,15 @@ class BotanConan(ConanFile):
         tools.get("{0}/archive/{1}.tar.gz".format(self.homepage, self.version))
         extracted_dir = "botan-" + self.version
         os.rename(extracted_dir, "sources")
+
+        # This patch is required to build the amalgamation build on Xcode 9 and
+        # before. It will (likely) be included in the next Botan release. Hence,
+        # we should be able to remove that for Botan 2.11.0 and beyond...
+        #
+        # See associated PR in Botan:
+        #   https://github.com/randombit/botan/pull/1884
+        with tools.chdir("sources"):
+            tools.patch(patch_file='../2006b469c1d1038737c1afe908300fab87d50062.diff')
 
     def build(self):
         with tools.chdir('sources'):


### PR DESCRIPTION
This adds recipe fixes and enhancements for Botan 2.10.0.

* use `./configure.py --extra-cxxflags`
* link against `CoreFoundation` because of [macOS certificate store integration](https://github.com/randombit/botan/pull/1830)

Related to [this bincrafters community ticket](https://github.com/bincrafters/community/issues/712).