### PR TITLE
Allow enabling specific botan modules

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -30,6 +30,7 @@ class BotanConan(ConanFile):
         'sqlite3': [True, False],
         'zlib': [True, False],
         'boost': [True, False],
+        'enable_modules': "ANY",
         'system_cert_bundle': "ANY"
     }
     default_options = {'amalgamation': True,
@@ -43,6 +44,7 @@ class BotanConan(ConanFile):
                        'sqlite3': False,
                        'zlib': False,
                        'boost': False,
+                       'enable_modules': None,
                        'system_cert_bundle': None}
 
     def configure(self):
@@ -170,6 +172,10 @@ class BotanConan(ConanFile):
         if environment_cxxflags:
             del os.environ["CXXFLAGS"]
             botan_extra_cxx_flags.append(environment_cxxflags)
+
+        if self.options.enable_modules:
+            build_flags.append('--minimized-build')
+            build_flags.append('--enable-modules={}'.format(self.options.enable_modules))
 
         if self.options.amalgamation:
             build_flags.append('--amalgamation')


### PR DESCRIPTION
The Botan library is [highly customisable](https://botan.randombit.net/handbook/building.html#configuring-the-build) with a plethora of modules. That provides consumers of the library with fine-grained control of which algorithms and protocols are to be compiled into the library.

This conan recipe is currently defaulting to "build everything", which is somewhat sad, given the possiblities Botan provides. Obviously, tuning this list is fairly hard, but the recipe should give the possiblity to the consumer.

I'd like to add an optional parameter `enable_modules` that takes a comma-separated list of modules that the build should contain. If it is not provided, the recipe will fall back to "build everything" again.