### PR TITLE
FIX: use tools.cpu_count() during build()

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-from multiprocessing import cpu_count
 from conans import ConanFile, tools
 from conans.errors import ConanException, ConanInvalidConfiguration
 from conans.model.version import Version
@@ -296,7 +295,7 @@ class BotanConan(ConanFile):
                         ldflags=make_ldflags,
                         make=self._make_program,
                         quiet=botan_quiet,
-                        cpucount=cpu_count())
+                        cpucount=tools.cpu_count())
         return make_cmd
 
     @property


### PR DESCRIPTION
This recipe used python `multiprocessing.cpu_count()` to determine the number of build jobs. Though, prevents any benefit from using distributed compilation via `distcc` or `icecream`. It now uses `conans.tools.cpu_count()` that takes the `cpu_count` setting in `conan.conf` into account.