### PR TITLE
fix copy-paste mistake to make travis happy again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
       - <<: *linux
-        env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
+        env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8 CONAN_ARCHS=x86_64
       - <<: *linux
-        env: CONAN_CLANG_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_ARCHS=x86_64
+        env: CONAN_CLANG_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/clang9 CONAN_ARCHS=x86_64
       - <<: *osx
         osx_image: xcode9.4
         env: CONAN_APPLE_CLANG_VERSIONS=9.1


### PR DESCRIPTION
Configurations to test clang 8 and 9 on linux now use the docker image appropriate to the clang version specified in the environment.